### PR TITLE
Added zero length check to ratings in `models/product.py`

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -11,20 +11,35 @@ from .productrating import ProductRating
 class Product(SafeDeleteModel):
 
     _safedelete_policy = SOFT_DELETE
-    name = models.CharField(max_length=50,)
+    name = models.CharField(
+        max_length=50,
+    )
     customer = models.ForeignKey(
-        Customer, on_delete=models.DO_NOTHING, related_name='products')
+        Customer, on_delete=models.DO_NOTHING, related_name="products"
+    )
     price = models.FloatField(
-        validators=[MinValueValidator(0.00), MaxValueValidator(10000.00)],)
-    description = models.CharField(max_length=255,)
-    quantity = models.IntegerField(validators=[MinValueValidator(0)],)
+        validators=[MinValueValidator(0.00), MaxValueValidator(10000.00)],
+    )
+    description = models.CharField(
+        max_length=255,
+    )
+    quantity = models.IntegerField(
+        validators=[MinValueValidator(0)],
+    )
     created_date = models.DateField(auto_now_add=True)
     category = models.ForeignKey(
-        ProductCategory, on_delete=models.DO_NOTHING, related_name='products')
-    location = models.CharField(max_length=50,)
+        ProductCategory, on_delete=models.DO_NOTHING, related_name="products"
+    )
+    location = models.CharField(
+        max_length=50,
+    )
     image_path = models.ImageField(
-        upload_to='products', height_field=None,
-        width_field=None, max_length=None, null=True)
+        upload_to="products",
+        height_field=None,
+        width_field=None,
+        max_length=None,
+        null=True,
+    )
 
     @property
     def number_sold(self):
@@ -34,7 +49,8 @@ class Product(SafeDeleteModel):
             int -- Number items on completed orders
         """
         sold = OrderProduct.objects.filter(
-            product=self, order__payment_type__isnull=False)
+            product=self, order__payment_type__isnull=False
+        )
         return sold.count()
 
     @property
@@ -58,6 +74,11 @@ class Product(SafeDeleteModel):
             number -- The average rating for the product
         """
         ratings = ProductRating.objects.filter(product=self)
+
+        # return an average of 0 if there are no ratings
+        if len(ratings) < 1:
+            return 0
+
         total_rating = 0
         for rating in ratings:
             total_rating += rating.rating
@@ -66,5 +87,5 @@ class Product(SafeDeleteModel):
         return avg
 
     class Meta:
-        verbose_name = ("product")
-        verbose_name_plural = ("products")
+        verbose_name = "product"
+        verbose_name_plural = "products"


### PR DESCRIPTION
The average rating method of the Product model was trying to divide by zero when there were no ratings for that product. This change adds a check for length of zero and returns an average of zero before trying any calculations.

## Changes

- `bangazonapi/models/product.py`
  - added check to line 78
  - ```py
        # return an average of 0 if there are no ratings
        if len(ratings) < 1:
            return 0
     ```

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/products` gets all products

**Response**

HTTP/1.1 200 OK

```json
[
  {
    "id": 1,
    "name": "Optima",
    "price": 1655.15,
    "number_sold": 0,
    "description": "2008 Kia",
    "quantity": 3,
    "created_date": "2019-05-21",
    "location": "Seoul",
    "image_path": "http://localhost:8000/media/products/vehicle.png",
    "average_rating": 0
  },
  {
    "id": 2,
    "name": "Golf",
    "price": 653.59,
    "number_sold": 0,
    "description": "1994 Volkswagen",
    "quantity": 4,
    "created_date": "2019-07-10",
    "location": "Paris",
    "image_path": "http://localhost:8000/media/products/vehicle.png",
    "average_rating": 0
  },
  ...
]
```

## Testing

Description of how to test code...

- [ ] Pull this API branch
- [ ] Run `./seed_data.sh`
- [ ] Run/restart debugger
- [ ] Get products and check that products are returned


## Related Issues

- Fixes #6 