### PR TITLE
9 bug payment type info is incorrect

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
In ```views/paymenttype.py```, the creation date and expiration date values are matching their corresponding key in the payment type data in the create method.

## Changes

```py
        new_payment.expiration_date = request.data["expiration_date"]
        new_payment.create_date = request.data["create_date"]
```


## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

POST `/paymenttypes` Creates a new payment type

```json
{
    "merchant_name": "Visa",
    "account_number": "111111111111",
    "expiration_date": "2024-12-12",
    "create_date": "2022-12-12"
}
```

**Response**

HTTP/1.1 201 Created

```json
{
  "id": 5,
  "url": "http://localhost:8000/paymenttypes/5",
  "merchant_name": "Visa",
  "account_number": "111111111111",
  "expiration_date": "2024-12-12",
  "create_date": "2022-12-12"
}
```

## Testing

Description of how to test code...

- [x] Run debugger
- [x] Seed database (./seed-data.sh)
- [x] Open yaak
- [x] Go to 'Create a payment type' tab
- [x] Copy and paste above json block for testing
- [x] you should receive the response below testing block, possibly with a different id
- [x] check the create and expiration dates to see if they match


## Related Issues

- Fixes https://github.com/NSS-Day-Cohort-79/Bangazon-api-hrmjnv/issues/9