### PR TITLE
4 bug products last order

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -1,4 +1,5 @@
 """View module for handling requests about customer order"""
+
 import datetime
 from django.http import HttpResponseServerError
 from rest_framework.viewsets import ViewSet
@@ -11,18 +12,18 @@ from .product import ProductSerializer
 
 
 class OrderLineItemSerializer(serializers.HyperlinkedModelSerializer):
-    """JSON serializer for line items """
+    """JSON serializer for line items"""
 
     product = ProductSerializer(many=False)
 
     class Meta:
         model = OrderProduct
         url = serializers.HyperlinkedIdentityField(
-            view_name='lineitem',
-            lookup_field='id'
+            view_name="lineitem", lookup_field="id"
         )
-        fields = ('id', 'product')
+        fields = ("id", "product")
         depth = 1
+
 
 class OrderSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for customer orders"""
@@ -31,11 +32,8 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Order
-        url = serializers.HyperlinkedIdentityField(
-            view_name='order',
-            lookup_field='id'
-        )
-        fields = ('id', 'url', 'created_date', 'payment_type', 'customer', 'lineitems')
+        url = serializers.HyperlinkedIdentityField(view_name="order", lookup_field="id")
+        fields = ("id", "url", "created_date", "payment_type", "customer", "lineitems")
 
 
 class Orders(ViewSet):
@@ -70,13 +68,15 @@ class Orders(ViewSet):
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order = Order.objects.get(pk=pk, customer=customer)
-            serializer = OrderSerializer(order, context={'request': request})
+            serializer = OrderSerializer(order, context={"request": request})
             return Response(serializer.data)
 
         except Order.DoesNotExist as ex:
             return Response(
-                {'message': 'The requested order does not exist, or you do not have permission to access it.'},
-                status=status.HTTP_404_NOT_FOUND
+                {
+                    "message": "The requested order does not exist, or you do not have permission to access it."
+                },
+                status=status.HTTP_404_NOT_FOUND,
             )
 
         except Exception as ex:
@@ -104,7 +104,8 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
+        payment = Payment.objects.get(pk=request.data["payment_type"])
+        order.payment_type = payment
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)
@@ -142,11 +143,10 @@ class Orders(ViewSet):
         customer = Customer.objects.get(user=request.auth.user)
         orders = Order.objects.filter(customer=customer)
 
-        payment = self.request.query_params.get('payment_id', None)
+        payment = self.request.query_params.get("payment_id", None)
         if payment is not None:
             orders = orders.filter(payment__id=payment)
 
-        json_orders = OrderSerializer(
-            orders, many=True, context={'request': request})
+        json_orders = OrderSerializer(orders, many=True, context={"request": request})
 
         return Response(json_orders.data)

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -237,7 +237,7 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()


### PR DESCRIPTION
Fixes several bugs across the cart, payment type, and product rating features of the Bangazon API.

## Changes

- Added `payment_type=None` filter to cart POST so it no longer returns a closed order instead of creating a new open one
- Fixed order update (PATCH) to assign the `Payment` object instance instead of the raw ID when setting `payment_type`

## Requests / Responses

No new or changed request/response shapes — all fixes are behavioral corrections to existing endpoints.

## Testing

- [x] Run `./seed_data.sh`
- [x] Run debugger
- [x] Get an auth token and make sure it's the same for all following requests
  - (9ba45f09651c5b0c404f37a2d2572c026c14669c)
- [x] GET `/profile/cart` — get order id of open order (2) and check that payment_type is null
- [x] PUT to `/orders/:id` (2) with a payment type ID to close the order
  - ```json
    {
        "payment_type": 1
    }
    ```
- [x] GET `/orders/:id` (2) — make sure the payment type was set
- [x] GET `/profile/cart` — check that no open order returned
- [x] POST `/profile/cart` — add a new item to the cart
  - ```json
     {
        "product_id": 88
     }
    ```
- [x] GET `/profile/cart` — check that new order id is created (11)

## Related Issues

- Fixes #4