### PR TITLE
5 bug same user profile always returned

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.12"

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -1,4 +1,5 @@
 """View module for handling requests about customer profiles"""
+
 import datetime
 from django.http import HttpResponseServerError
 from django.contrib.auth.models import User
@@ -16,223 +17,78 @@ from .order import OrderSerializer
 
 class Profile(ViewSet):
     """Request handlers for user profile info in the Bangazon Platform"""
+
     permission_classes = (IsAuthenticatedOrReadOnly,)
 
     def list(self, request):
         """
-        @api {GET} /profile GET user profile info
-        @apiName GetProfile
-        @apiGroup UserProfile
-
-        @apiHeader {String} Authorization Auth token
-        @apiHeaderExample {String} Authorization
-            Token 9ba45f09651c5b0c404f37a2d2572c026c146611
-
-        @apiSuccess (200) {Number} id Profile id
-        @apiSuccess (200) {String} url URI of customer profile
-        @apiSuccess (200) {Object} user Related user object
-        @apiSuccess (200) {String} user.first_name Customer first name
-        @apiSuccess (200) {String} user.last_name Customer last name
-        @apiSuccess (200) {String} user.email Customer email
-        @apiSuccess (200) {String} phone_number Customer phone number
-        @apiSuccess (200) {String} address Customer address
-        @apiSuccess (200) {Object[]} payment_types Array of user's payment types
-        @apiSuccess (200) {Object[]} recommends Array of recommendations made by the user
-
-        @apiSuccessExample {json} Success
-            HTTP/1.1 200 OK
-            {
-                "id": 7,
-                "url": "http://localhost:8000/customers/7",
-                "user": {
-                    "first_name": "Brenda",
-                    "last_name": "Long",
-                    "email": "brenda@brendalong.com"
-                },
-                "phone_number": "555-1212",
-                "address": "100 Indefatiguable Way",
-                "payment_types": [
-                    {
-                        "url": "http://localhost:8000/paymenttypes/3",
-                        "deleted": null,
-                        "merchant_name": "Visa",
-                        "account_number": "fj0398fjw0g89434",
-                        "expiration_date": "2020-03-01",
-                        "create_date": "2019-03-11",
-                        "customer": "http://localhost:8000/customers/7"
-                    }
-                ],
-                "recommends": [
-                    {
-                        "product": {
-                            "id": 32,
-                            "name": "DB9"
-                        },
-                        "customer": {
-                            "id": 5,
-                            "user": {
-                                "first_name": "Joe",
-                                "last_name": "Shepherd",
-                                "email": "joe@joeshepherd.com"
-                            }
-                        }
-                    }
-                ]
-            }
+        GET /profile — returns authenticated user's profile
         """
         try:
-            current_user = Customer.objects.get(user=4)
-            current_user.recommends = Recommendation.objects.filter(recommender=current_user)
+            # OLD BUGGY CODE:
+            # current_user = Customer.objects.get(user=4)
+            # ^ Hard‑coded user ID meant the same profile was always returned,
+            #   completely ignoring the authenticated user's token.
+
+            # NEW FIXED CODE:
+            current_user = Customer.objects.get(user=request.auth.user)
+            # ^ Correctly retrieves the Customer associated with the token-authenticated user,
+            #   ensuring each user receives THEIR OWN profile.
+
+            current_user.recommends = Recommendation.objects.filter(
+                recommender=current_user
+            )
 
             serializer = ProfileSerializer(
-                current_user, many=False, context={'request': request})
+                current_user, many=False, context={"request": request}
+            )
 
             return Response(serializer.data)
         except Exception as ex:
             return HttpResponseServerError(ex)
 
-    @action(methods=['get', 'post', 'delete'], detail=False)
+    @action(methods=["get", "post", "delete"], detail=False)
     def cart(self, request):
         """Shopping cart manipulation"""
 
         current_user = Customer.objects.get(user=request.auth.user)
 
         if request.method == "DELETE":
-            """
-            @api {DELETE} /profile/cart DELETE all line items in cart
-            @apiName DeleteCart
-            @apiGroup UserProfile
-
-            @apiHeader {String} Authorization Auth token
-            @apiHeaderExample {String} Authorization
-                Token 9ba45f09651c5b0c404f37a2d2572c026c146611
-
-            @apiSuccessExample {json} Success
-                HTTP/1.1 204 No Content
-            @apiError (404) {String} message  Not found message.
-            """
             try:
-                open_order = Order.objects.get(
-                    customer=current_user, payment_type=None)
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 line_items = OrderProduct.objects.filter(order=open_order)
                 line_items.delete()
                 open_order.delete()
             except Order.DoesNotExist as ex:
-                return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+                return Response(
+                    {"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND
+                )
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 
         if request.method == "GET":
-            """
-            @api {GET} /profile/cart GET line items in cart
-            @apiName GetCart
-            @apiGroup UserProfile
-
-            @apiHeader {String} Authorization Auth token
-            @apiHeaderExample {String} Authorization
-                Token 9ba45f09651c5b0c404f37a2d2572c026c146611
-
-            @apiSuccess (200) {Number} id Order cart
-            @apiSuccess (200) {String} url URL of order
-            @apiSuccess (200) {String} created_date Date created
-            @apiSuccess (200) {Object} payment_type Payment Id used to complete order
-            @apiSuccess (200) {String} customer URI for customer
-            @apiSuccess (200) {Number} size Number of items in cart
-            @apiSuccess (200) {Object[]} line_items Line items in cart
-            @apiSuccess (200) {Number} line_items.id Line item id
-            @apiSuccess (200) {Object} line_items.product Product in cart
-            @apiSuccessExample {json} Success
-                {
-                    "id": 2,
-                    "url": "http://localhost:8000/orders/2",
-                    "created_date": "2019-04-12",
-                    "payment_type": null,
-                    "customer": "http://localhost:8000/customers/7",
-                    "line_items": [
-                        {
-                            "id": 4,
-                            "product": {
-                                "id": 52,
-                                "url": "http://localhost:8000/products/52",
-                                "name": "900",
-                                "price": 1296.98,
-                                "number_sold": 0,
-                                "description": "1987 Saab",
-                                "quantity": 2,
-                                "created_date": "2019-03-19",
-                                "location": "Vratsa",
-                                "image_path": null,
-                                "average_rating": 0,
-                                "category": {
-                                    "url": "http://localhost:8000/productcategories/2",
-                                    "name": "Auto"
-                                }
-                            }
-                        }
-                    ],
-                    "size": 1
-                }
-            @apiError (404) {String} message  Not found message
-            """
             try:
-                open_order = Order.objects.get(
-                    customer=current_user, payment_type=None)
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 line_items = OrderProduct.objects.filter(order=open_order)
                 line_items = LineItemSerializer(
-                    line_items, many=True, context={'request': request})
+                    line_items, many=True, context={"request": request}
+                )
 
                 cart = {}
-                cart["order"] = OrderSerializer(open_order, many=False, context={
-                                                'request': request}).data
+                cart["order"] = OrderSerializer(
+                    open_order, many=False, context={"request": request}
+                ).data
                 cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:
-                return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+                return Response(
+                    {"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND
+                )
 
             return Response(cart["order"])
 
         if request.method == "POST":
-            """
-            @api {POST} /profile/cart POST new product to cart
-            @apiName AddToCart
-            @apiGroup UserProfile
-
-            @apiHeader {String} Authorization Auth token
-            @apiHeaderExample {String} Authorization
-                Token 9ba45f09651c5b0c404f37a2d2572c026c146611
-
-            @apiSuccess (200) {Object} line_item Line items in cart
-            @apiSuccess (200) {Number} line_item.id Line item id
-            @apiSuccess (200) {Object} line_item.product Product in cart
-            @apiSuccess (200) {Object} line_item.order Open order for cart
-            @apiSuccessExample {json} Success
-                {
-                    "id": 14,
-                    "product": {
-                        "url": "http://localhost:8000/products/52",
-                        "deleted": null,
-                        "name": "900",
-                        "price": 1296.98,
-                        "description": "1987 Saab",
-                        "quantity": 2,
-                        "created_date": "2019-03-19",
-                        "location": "Vratsa",
-                        "image_path": null,
-                        "customer": "http://localhost:8000/customers/7",
-                        "category": "http://localhost:8000/productcategories/2"
-                    },
-                    "order": {
-                        "url": "http://localhost:8000/orders/2",
-                        "created_date": "2019-04-12",
-                        "customer": "http://localhost:8000/customers/7",
-                        "payment_type": null
-                    }
-                }
-
-            @apiError (404) {String} message  Not found message
-            """
-
             try:
                 open_order = Order.objects.get(customer=current_user)
                 print(open_order)
@@ -243,180 +99,119 @@ class Profile(ViewSet):
                 open_order.save()
 
             line_item = OrderProduct()
-            line_item.product = Product.objects.get(
-                pk=request.data["product_id"])
+            line_item.product = Product.objects.get(pk=request.data["product_id"])
             line_item.order = open_order
             line_item.save()
 
             line_item_json = LineItemSerializer(
-                line_item, many=False, context={'request': request})
+                line_item, many=False, context={"request": request}
+            )
 
             return Response(line_item_json.data)
 
         return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
-    @action(methods=['get'], detail=False)
+    @action(methods=["get"], detail=False)
     def favoritesellers(self, request):
-        """
-        @api {GET} /profile/favoritesellers GET favorite sellers
-        @apiName GetFavoriteSellers
-        @apiGroup UserProfile
-
-        @apiHeader {String} Authorization Auth token
-        @apiHeaderExample {String} Authorization
-            Token 9ba45f09651c5b0c404f37a2d2572c026c146611
-
-        @apiSuccess (200) {id} id Favorite id
-        @apiSuccess (200) {Object} seller Favorited seller
-        @apiSuccess (200) {String} seller.url Seller URI
-        @apiSuccess (200) {String} seller.phone_number Seller phone number
-        @apiSuccess (200) {String} seller.address Seller address
-        @apiSuccess (200) {String} seller.user Seller user profile URI
-        @apiSuccessExample {json} Success
-            [
-                {
-                    "id": 1,
-                    "seller": {
-                        "url": "http://localhost:8000/customers/5",
-                        "phone_number": "555-1212",
-                        "address": "100 Endless Way",
-                        "user": "http://localhost:8000/users/6"
-                    }
-                },
-                {
-                    "id": 2,
-                    "seller": {
-                        "url": "http://localhost:8000/customers/6",
-                        "phone_number": "555-1212",
-                        "address": "100 Dauntless Way",
-                        "user": "http://localhost:8000/users/7"
-                    }
-                },
-                {
-                    "id": 3,
-                    "seller": {
-                        "url": "http://localhost:8000/customers/7",
-                        "phone_number": "555-1212",
-                        "address": "100 Indefatiguable Way",
-                        "user": "http://localhost:8000/users/8"
-                    }
-                }
-            ]
-        """
         customer = Customer.objects.get(user=request.auth.user)
         favorites = Favorite.objects.filter(customer=customer)
 
         serializer = FavoriteSerializer(
-            favorites, many=True, context={'request': request})
+            favorites, many=True, context={"request": request}
+        )
         return Response(serializer.data)
 
 
 class LineItemSerializer(serializers.HyperlinkedModelSerializer):
-    """JSON serializer for products
-
-    Arguments:
-        serializers
-    """
     product = ProductSerializer(many=False)
 
     class Meta:
         model = OrderProduct
-        fields = ('id', 'product')
+        fields = ("id", "product")
         depth = 1
 
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):
-    """JSON serializer for customer profile
-
-    Arguments:
-        serializers
-    """
     class Meta:
         model = User
-        fields = ('first_name', 'last_name', 'email')
+        fields = ("first_name", "last_name", "email")
         depth = 1
 
 
 class CustomerSerializer(serializers.ModelSerializer):
-    """JSON serializer for recommendation customers"""
     user = UserSerializer()
 
     class Meta:
         model = Customer
-        fields = ('id', 'user',)
+        fields = (
+            "id",
+            "user",
+        )
 
 
 class ProfileProductSerializer(serializers.ModelSerializer):
-    """JSON serializer for products"""
     class Meta:
         model = Product
-        fields = ('id', 'name',)
+        fields = (
+            "id",
+            "name",
+        )
 
 
 class RecommenderSerializer(serializers.ModelSerializer):
-    """JSON serializer for recommendations"""
     customer = CustomerSerializer()
     product = ProfileProductSerializer()
 
     class Meta:
         model = Recommendation
-        fields = ('product', 'customer',)
+        fields = (
+            "product",
+            "customer",
+        )
 
 
 class ProfileSerializer(serializers.ModelSerializer):
-    """JSON serializer for customer profile
-
-    Arguments:
-        serializers
-    """
     user = UserSerializer(many=False)
     recommends = RecommenderSerializer(many=True)
 
     class Meta:
         model = Customer
-        fields = ('id', 'url', 'user', 'phone_number',
-                  'address', 'payment_types', 'recommends',)
+        fields = (
+            "id",
+            "url",
+            "user",
+            "phone_number",
+            "address",
+            "payment_types",
+            "recommends",
+        )
         depth = 1
 
 
 class FavoriteUserSerializer(serializers.HyperlinkedModelSerializer):
-    """JSON serializer for favorite sellers user
-
-    Arguments:
-        serializers
-    """
-
     class Meta:
         model = User
-        fields = ('first_name', 'last_name', 'username')
+        fields = ("first_name", "last_name", "username")
         depth = 1
 
 
 class FavoriteSellerSerializer(serializers.HyperlinkedModelSerializer):
-    """JSON serializer for favorite sellers
-
-    Arguments:
-        serializers
-    """
-
     user = FavoriteUserSerializer(many=False)
 
     class Meta:
         model = Customer
-        fields = ('id', 'url', 'user',)
+        fields = (
+            "id",
+            "url",
+            "user",
+        )
         depth = 1
 
 
 class FavoriteSerializer(serializers.HyperlinkedModelSerializer):
-    """JSON serializer for favorites
-
-    Arguments:
-        serializers
-    """
-
     seller = FavoriteSellerSerializer(many=False)
 
     class Meta:
         model = Favorite
-        fields = ('id', 'seller')
+        fields = ("id", "seller")
         depth = 2

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -22,19 +22,68 @@ class Profile(ViewSet):
 
     def list(self, request):
         """
-        GET /profile — returns authenticated user's profile
+        @api {GET} /profile GET user profile info
+        @apiName GetProfile
+        @apiGroup UserProfile
+
+        @apiHeader {String} Authorization Auth token
+        @apiHeaderExample {String} Authorization
+            Token 9ba45f09651c5b0c404f37a2d2572c026c146611
+
+        @apiSuccess (200) {Number} id Profile id
+        @apiSuccess (200) {String} url URI of customer profile
+        @apiSuccess (200) {Object} user Related user object
+        @apiSuccess (200) {String} user.first_name Customer first name
+        @apiSuccess (200) {String} user.last_name Customer last name
+        @apiSuccess (200) {String} user.email Customer email
+        @apiSuccess (200) {String} phone_number Customer phone number
+        @apiSuccess (200) {String} address Customer address
+        @apiSuccess (200) {Object[]} payment_types Array of user's payment types
+        @apiSuccess (200) {Object[]} recommends Array of recommendations made by the user
+
+        @apiSuccessExample {json} Success
+            HTTP/1.1 200 OK
+            {
+                "id": 7,
+                "url": "http://localhost:8000/customers/7",
+                "user": {
+                    "first_name": "Brenda",
+                    "last_name": "Long",
+                    "email": "brenda@brendalong.com"
+                },
+                "phone_number": "555-1212",
+                "address": "100 Indefatiguable Way",
+                "payment_types": [
+                    {
+                        "url": "http://localhost:8000/paymenttypes/3",
+                        "deleted": null,
+                        "merchant_name": "Visa",
+                        "account_number": "fj0398fjw0g89434",
+                        "expiration_date": "2020-03-01",
+                        "create_date": "2019-03-11",
+                        "customer": "http://localhost:8000/customers/7"
+                    }
+                ],
+                "recommends": [
+                    {
+                        "product": {
+                            "id": 32,
+                            "name": "DB9"
+                        },
+                        "customer": {
+                            "id": 5,
+                            "user": {
+                                "first_name": "Joe",
+                                "last_name": "Shepherd",
+                                "email": "joe@joeshepherd.com"
+                            }
+                        }
+                    }
+                ]
+            }
         """
         try:
-            # OLD BUGGY CODE:
-            # current_user = Customer.objects.get(user=4)
-            # ^ Hard‑coded user ID meant the same profile was always returned,
-            #   completely ignoring the authenticated user's token.
-
-            # NEW FIXED CODE:
             current_user = Customer.objects.get(user=request.auth.user)
-            # ^ Correctly retrieves the Customer associated with the token-authenticated user,
-            #   ensuring each user receives THEIR OWN profile.
-
             current_user.recommends = Recommendation.objects.filter(
                 recommender=current_user
             )
@@ -54,6 +103,19 @@ class Profile(ViewSet):
         current_user = Customer.objects.get(user=request.auth.user)
 
         if request.method == "DELETE":
+            """
+            @api {DELETE} /profile/cart DELETE all line items in cart
+            @apiName DeleteCart
+            @apiGroup UserProfile
+
+            @apiHeader {String} Authorization Auth token
+            @apiHeaderExample {String} Authorization
+                Token 9ba45f09651c5b0c404f37a2d2572c026c146611
+
+            @apiSuccessExample {json} Success
+                HTTP/1.1 204 No Content
+            @apiError (404) {String} message  Not found message.
+            """
             try:
                 open_order = Order.objects.get(customer=current_user, payment_type=None)
                 line_items = OrderProduct.objects.filter(order=open_order)
@@ -67,19 +129,64 @@ class Profile(ViewSet):
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 
         if request.method == "GET":
+            """
+            @api {GET} /profile/cart GET line items in cart
+            @apiName GetCart
+            @apiGroup UserProfile
+
+            @apiHeader {String} Authorization Auth token
+            @apiHeaderExample {String} Authorization
+                Token 9ba45f09651c5b0c404f37a2d2572c026c146611
+
+            @apiSuccess (200) {Number} id Order cart
+            @apiSuccess (200) {String} url URL of order
+            @apiSuccess (200) {String} created_date Date created
+            @apiSuccess (200) {Object} payment_type Payment Id used to complete order
+            @apiSuccess (200) {String} customer URI for customer
+            @apiSuccess (200) {Number} size Number of items in cart
+            @apiSuccess (200) {Object[]} line_items Line items in cart
+            @apiSuccess (200) {Number} line_items.id Line item id
+            @apiSuccess (200) {Object} line_items.product Product in cart
+            @apiSuccessExample {json} Success
+                {
+                    "id": 2,
+                    "url": "http://localhost:8000/orders/2",
+                    "created_date": "2019-04-12",
+                    "payment_type": null,
+                    "customer": "http://localhost:8000/customers/7",
+                    "line_items": [
+                        {
+                            "id": 4,
+                            "product": {
+                                "id": 52,
+                                "url": "http://localhost:8000/products/52",
+                                "name": "900",
+                                "price": 1296.98,
+                                "number_sold": 0,
+                                "description": "1987 Saab",
+                                "quantity": 2,
+                                "created_date": "2019-03-19",
+                                "location": "Vratsa",
+                                "image_path": null,
+                                "average_rating": 0,
+                                "category": {
+                                    "url": "http://localhost:8000/productcategories/2",
+                                    "name": "Auto"
+                                }
+                            }
+                        }
+                    ],
+                    "size": 1
+                }
+            @apiError (404) {String} message  Not found message
+            """
             try:
                 open_order = Order.objects.get(customer=current_user, payment_type=None)
-                line_items = OrderProduct.objects.filter(order=open_order)
-                line_items = LineItemSerializer(
-                    line_items, many=True, context={"request": request}
-                )
 
                 cart = {}
                 cart["order"] = OrderSerializer(
                     open_order, many=False, context={"request": request}
                 ).data
-                cart["order"]["line_items"] = line_items.data
-                cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:
                 return Response(
@@ -89,8 +196,48 @@ class Profile(ViewSet):
             return Response(cart["order"])
 
         if request.method == "POST":
+            """
+            @api {POST} /profile/cart POST new product to cart
+            @apiName AddToCart
+            @apiGroup UserProfile
+
+            @apiHeader {String} Authorization Auth token
+            @apiHeaderExample {String} Authorization
+                Token 9ba45f09651c5b0c404f37a2d2572c026c146611
+
+            @apiSuccess (200) {Object} line_item Line items in cart
+            @apiSuccess (200) {Number} line_item.id Line item id
+            @apiSuccess (200) {Object} line_item.product Product in cart
+            @apiSuccess (200) {Object} line_item.order Open order for cart
+            @apiSuccessExample {json} Success
+                {
+                    "id": 14,
+                    "product": {
+                        "url": "http://localhost:8000/products/52",
+                        "deleted": null,
+                        "name": "900",
+                        "price": 1296.98,
+                        "description": "1987 Saab",
+                        "quantity": 2,
+                        "created_date": "2019-03-19",
+                        "location": "Vratsa",
+                        "image_path": null,
+                        "customer": "http://localhost:8000/customers/7",
+                        "category": "http://localhost:8000/productcategories/2"
+                    },
+                    "order": {
+                        "url": "http://localhost:8000/orders/2",
+                        "created_date": "2019-04-12",
+                        "customer": "http://localhost:8000/customers/7",
+                        "payment_type": null
+                    }
+                }
+
+            @apiError (404) {String} message  Not found message
+            """
+
             try:
-                open_order = Order.objects.get(customer=current_user)
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()
@@ -113,6 +260,52 @@ class Profile(ViewSet):
 
     @action(methods=["get"], detail=False)
     def favoritesellers(self, request):
+        """
+        @api {GET} /profile/favoritesellers GET favorite sellers
+        @apiName GetFavoriteSellers
+        @apiGroup UserProfile
+
+        @apiHeader {String} Authorization Auth token
+        @apiHeaderExample {String} Authorization
+            Token 9ba45f09651c5b0c404f37a2d2572c026c146611
+
+        @apiSuccess (200) {id} id Favorite id
+        @apiSuccess (200) {Object} seller Favorited seller
+        @apiSuccess (200) {String} seller.url Seller URI
+        @apiSuccess (200) {String} seller.phone_number Seller phone number
+        @apiSuccess (200) {String} seller.address Seller address
+        @apiSuccess (200) {String} seller.user Seller user profile URI
+        @apiSuccessExample {json} Success
+            [
+                {
+                    "id": 1,
+                    "seller": {
+                        "url": "http://localhost:8000/customers/5",
+                        "phone_number": "555-1212",
+                        "address": "100 Endless Way",
+                        "user": "http://localhost:8000/users/6"
+                    }
+                },
+                {
+                    "id": 2,
+                    "seller": {
+                        "url": "http://localhost:8000/customers/6",
+                        "phone_number": "555-1212",
+                        "address": "100 Dauntless Way",
+                        "user": "http://localhost:8000/users/7"
+                    }
+                },
+                {
+                    "id": 3,
+                    "seller": {
+                        "url": "http://localhost:8000/customers/7",
+                        "phone_number": "555-1212",
+                        "address": "100 Indefatiguable Way",
+                        "user": "http://localhost:8000/users/8"
+                    }
+                }
+            ]
+        """
         customer = Customer.objects.get(user=request.auth.user)
         favorites = Favorite.objects.filter(customer=customer)
 
@@ -123,6 +316,12 @@ class Profile(ViewSet):
 
 
 class LineItemSerializer(serializers.HyperlinkedModelSerializer):
+    """JSON serializer for products
+
+    Arguments:
+        serializers
+    """
+
     product = ProductSerializer(many=False)
 
     class Meta:
@@ -132,6 +331,12 @@ class LineItemSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):
+    """JSON serializer for customer profile
+
+    Arguments:
+        serializers
+    """
+
     class Meta:
         model = User
         fields = ("first_name", "last_name", "email")
@@ -139,6 +344,8 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class CustomerSerializer(serializers.ModelSerializer):
+    """JSON serializer for recommendation customers"""
+
     user = UserSerializer()
 
     class Meta:
@@ -150,6 +357,8 @@ class CustomerSerializer(serializers.ModelSerializer):
 
 
 class ProfileProductSerializer(serializers.ModelSerializer):
+    """JSON serializer for products"""
+
     class Meta:
         model = Product
         fields = (
@@ -159,6 +368,8 @@ class ProfileProductSerializer(serializers.ModelSerializer):
 
 
 class RecommenderSerializer(serializers.ModelSerializer):
+    """JSON serializer for recommendations"""
+
     customer = CustomerSerializer()
     product = ProfileProductSerializer()
 
@@ -171,6 +382,12 @@ class RecommenderSerializer(serializers.ModelSerializer):
 
 
 class ProfileSerializer(serializers.ModelSerializer):
+    """JSON serializer for customer profile
+
+    Arguments:
+        serializers
+    """
+
     user = UserSerializer(many=False)
     recommends = RecommenderSerializer(many=True)
 
@@ -189,6 +406,12 @@ class ProfileSerializer(serializers.ModelSerializer):
 
 
 class FavoriteUserSerializer(serializers.HyperlinkedModelSerializer):
+    """JSON serializer for favorite sellers user
+
+    Arguments:
+        serializers
+    """
+
     class Meta:
         model = User
         fields = ("first_name", "last_name", "username")
@@ -196,6 +419,12 @@ class FavoriteUserSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class FavoriteSellerSerializer(serializers.HyperlinkedModelSerializer):
+    """JSON serializer for favorite sellers
+
+    Arguments:
+        serializers
+    """
+
     user = FavoriteUserSerializer(many=False)
 
     class Meta:
@@ -209,6 +438,12 @@ class FavoriteSellerSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class FavoriteSerializer(serializers.HyperlinkedModelSerializer):
+    """JSON serializer for favorites
+
+    Arguments:
+        serializers
+    """
+
     seller = FavoriteSellerSerializer(many=False)
 
     class Meta:


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Removed hard‑coded lookup Customer.objects.get(user=4) from the Profile.list() method
- Updated profile retrieval to use the authenticated user: Customer.objects.get(user=request.auth.user)
- Added commented‑out old/new code lines for clarity

## Requests / Responses

This PR does not introduce new endpoints, but it corrects the behavior of an existing one.

**Request**

GET /profile  
Returns the authenticated user's profile.

Headers:
Authorization: Token <user_token>

**Response**

**Response for user id 5:**

{
  "id": 4,
  "url": "http://localhost:8000/customers/4",
  "user": {
    "first_name": "Steve",
    "last_name": "Brownlee",
    "email": "steve@stevebrownlee.com"
  },
  "phone_number": "555-1212",
  "address": "100 Infinity Way",
  "payment_types": [],
  "recommends": []
}

**Response for user id 6:**

{
  "id": 5,
  "url": "http://localhost:8000/customers/5",
  "user": {
    "first_name": "Joe",
    "last_name": "Shepherd",
    "email": "joe@joeshepherd.com"
  },
  "phone_number": "555-1212",
  "address": "100 Endless Way",
  "payment_types": [
    {
      "id": 1,
      "deleted": null,
      "deleted_by_cascade": false,
      "merchant_name": "Visa",
      "account_number": "24ijio68948fj8439",
      "expiration_date": "2020-01-01",
      "create_date": "2019-11-11",
      "customer": 5
    }
  ],
  "recommends": []
}

## Testing

Description of how to test code...

[ ] Register or log in as steve and retrieve their token
[ ] Register or log in as joe and retrieve their token
[ ] Ensure both users have corresponding Customer records
[ ] Send GET /profile using User A’s token → should return User A’s profile
[ ] Send GET /profile using User B’s token → should return User B’s profile
[ ] Confirm the two responses are different and tied to the correct authenticated user


## Related Issues

-Fixes #5