### PR TITLE
Fix: Prevent unauthorized payment types on orders

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -105,8 +105,14 @@ class Orders(ViewSet):
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
         payment = Payment.objects.get(pk=request.data["payment_type"])
-        order.payment_type = payment
-        order.save()
+        if payment.customer == customer:
+            order.payment_type = payment
+            order.save()
+        else:
+            return Response(
+                "Payment doesn't belong to this customer",
+                status=status.HTTP_403_FORBIDDEN,
+            )
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
Users were able to assign payment types belonging to other customers when updating an order.

## Changes

- Added ownership check in `Orders.update` to verify the payment type belongs to the requesting customer before assigning it to an order
- Returns `403 Forbidden` with a descriptive message if the payment type does not belong to the customer

## Requests / Responses

**Request**

PUT `/orders/<id>` Updates an order's payment type

```json
{
    "payment_type": 7
}
```

**Response (success)**

HTTP/1.1 204 No Content

**Response (unauthorized payment type)**

HTTP/1.1 403 Forbidden

```
"Payment doesn't belong to this customer"
```

## Testing

- [x] Run ./seed_data.sh
- [x] Run debugger
- [x] Get Steve's token
- [x] Check Steve's cart
- [x] Try to Put a payment type of 1 to Steve's cart
- [x] Should get 403 unauthorized
- [x] Get Joe's token
- [x] Check Joe's cart
- [x] Try to put a payment type of 1 to Joe's order
- [x] Check that order now has a paymen type

## Related Issues

- Fixes #42