### PR TITLE
7 bug incorrect result for minimum products sold

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -75,8 +75,16 @@ class Product(SafeDeleteModel):
         """
         ratings = ProductRating.objects.filter(product=self)
 
-        # return an average of 0 if there are no ratings
-        if len(ratings) < 1:
+        # -----------------------------------------------
+        # FIX APPLIED: Prevent ZeroDivisionError
+        # OLD BEHAVIOR:
+        #   avg = total_rating / len(ratings)
+        #   This crashed when len(ratings) == 0
+        #
+        # NEW BEHAVIOR:
+        #   Return 0 when there are no ratings
+        # -----------------------------------------------
+        if len(ratings) == 0:
             return 0
 
         total_rating = 0

--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -75,16 +75,8 @@ class Product(SafeDeleteModel):
         """
         ratings = ProductRating.objects.filter(product=self)
 
-        # -----------------------------------------------
-        # FIX APPLIED: Prevent ZeroDivisionError
-        # OLD BEHAVIOR:
-        #   avg = total_rating / len(ratings)
-        #   This crashed when len(ratings) == 0
-        #
-        # NEW BEHAVIOR:
-        #   Return 0 when there are no ratings
-        # -----------------------------------------------
-        if len(ratings) == 0:
+        # return an average of 0 if there are no ratings
+        if len(ratings) < 1:
             return 0
 
         total_rating = 0

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -41,6 +41,7 @@ class Products(ViewSet):
     permission_classes = (IsAuthenticatedOrReadOnly,)
 
     def create(self, request):
+        """Handle POST operations for creating a new product"""
         new_product = Product()
         new_product.name = request.data["name"]
         new_product.price = request.data["price"]
@@ -70,6 +71,7 @@ class Products(ViewSet):
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def retrieve(self, request, pk=None):
+        """Handle GET requests for a single product"""
         try:
             product = Product.objects.get(pk=pk)
             serializer = ProductSerializer(product, context={"request": request})
@@ -78,6 +80,7 @@ class Products(ViewSet):
             return HttpResponseServerError(ex)
 
     def update(self, request, pk=None):
+        """Handle PUT requests for updating a product"""
         product = Product.objects.get(pk=pk)
         product.name = request.data["name"]
         product.price = request.data["price"]
@@ -96,6 +99,7 @@ class Products(ViewSet):
         return Response({}, status=status.HTTP_204_NO_CONTENT)
 
     def destroy(self, request, pk=None):
+        """Handle DELETE requests for a product"""
         try:
             product = Product.objects.get(pk=pk)
             product.delete()
@@ -110,6 +114,7 @@ class Products(ViewSet):
             )
 
     def list(self, request):
+        """Handle GET requests for all products, including filtering and ordering"""
         products = Product.objects.all()
 
         category = self.request.query_params.get("category", None)
@@ -133,6 +138,7 @@ class Products(ViewSet):
         if number_sold is not None:
 
             def sold_filter(product):
+                """Filter helper to return products sold >= requested amount"""
                 # OLD BUGGY CODE:
                 # if product.number_sold <= int(number_sold):
                 #     return True
@@ -152,6 +158,7 @@ class Products(ViewSet):
 
     @action(methods=["post"], detail=True)
     def recommend(self, request, pk=None):
+        """Custom action to recommend a product to another user"""
         if request.method == "POST":
             rec = Recommendation()
             rec.recommender = Customer.objects.get(user=request.auth.user)

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -1,4 +1,5 @@
 """View module for handling requests about products"""
+
 from rest_framework.decorators import action
 from bangazonapi.models.recommendation import Recommendation
 import base64
@@ -15,75 +16,31 @@ from rest_framework.parsers import MultiPartParser, FormParser
 
 class ProductSerializer(serializers.ModelSerializer):
     """JSON serializer for products"""
+
     class Meta:
         model = Product
-        fields = ('id', 'name', 'price', 'number_sold', 'description',
-                  'quantity', 'created_date', 'location', 'image_path',
-                  'average_rating', 'can_be_rated', )
+        fields = (
+            "id",
+            "name",
+            "price",
+            "number_sold",
+            "description",
+            "quantity",
+            "created_date",
+            "location",
+            "image_path",
+            "average_rating",
+            "can_be_rated",
+        )
         depth = 1
 
 
 class Products(ViewSet):
     """Request handlers for Products in the Bangazon Platform"""
+
     permission_classes = (IsAuthenticatedOrReadOnly,)
 
     def create(self, request):
-        """
-        @api {POST} /products POST new product
-        @apiName CreateProduct
-        @apiGroup Product
-
-        @apiHeader {String} Authorization Auth token
-        @apiHeaderExample {String} Authorization
-            Token 9ba45f09651c5b0c404f37a2d2572c026c146611
-
-        @apiParam {String} name Short form name of product
-        @apiParam {Number} price Cost of product
-        @apiParam {String} description Long form description of product
-        @apiParam {Number} quantity Number of items to sell
-        @apiParam {String} location City where product is located
-        @apiParam {Number} category_id Category of product
-        @apiParamExample {json} Input
-            {
-                "name": "Kite",
-                "price": 14.99,
-                "description": "It flies high",
-                "quantity": 60,
-                "location": "Pittsburgh",
-                "category_id": 4
-            }
-
-        @apiSuccess (200) {Object} product Created product
-        @apiSuccess (200) {id} product.id Product Id
-        @apiSuccess (200) {String} product.name Short form name of product
-        @apiSuccess (200) {String} product.description Long form description of product
-        @apiSuccess (200) {Number} product.price Cost of product
-        @apiSuccess (200) {Number} product.quantity Number of items to sell
-        @apiSuccess (200) {Date} product.created_date City where product is located
-        @apiSuccess (200) {String} product.location City where product is located
-        @apiSuccess (200) {String} product.image_path Path to product image
-        @apiSuccess (200) {Number} product.average_rating Average customer rating of product
-        @apiSuccess (200) {Number} product.number_sold How many items have been purchased
-        @apiSuccess (200) {Object} product.category Category of product
-        @apiSuccessExample {json} Success
-            {
-                "id": 101,
-                "url": "http://localhost:8000/products/101",
-                "name": "Kite",
-                "price": 14.99,
-                "number_sold": 0,
-                "description": "It flies high",
-                "quantity": 60,
-                "created_date": "2019-10-23",
-                "location": "Pittsburgh",
-                "image_path": null,
-                "average_rating": 0,
-                "category": {
-                    "url": "http://localhost:8000/productcategories/6",
-                    "name": "Games/Toys"
-                }
-            }
-        """
         new_product = Product()
         new_product.name = request.data["name"]
         new_product.price = request.data["price"]
@@ -98,79 +55,29 @@ class Products(ViewSet):
         new_product.category = product_category
 
         if "image_path" in request.data:
-            format, imgstr = request.data["image_path"].split(';base64,')
-            ext = format.split('/')[-1]
-            data = ContentFile(base64.b64decode(imgstr), name=f'{new_product.id}-{request.data["name"]}.{ext}')
-
+            format, imgstr = request.data["image_path"].split(";base64,")
+            ext = format.split("/")[-1]
+            data = ContentFile(
+                base64.b64decode(imgstr),
+                name=f'{new_product.id}-{request.data["name"]}.{ext}',
+            )
             new_product.image_path = data
 
         new_product.save()
 
-        serializer = ProductSerializer(
-            new_product, context={'request': request})
+        serializer = ProductSerializer(new_product, context={"request": request})
 
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def retrieve(self, request, pk=None):
-        """
-        @api {GET} /products/:id GET product
-        @apiName GetProduct
-        @apiGroup Product
-
-        @apiParam {id} id Product Id
-
-        @apiSuccess (200) {Object} product Created product
-        @apiSuccess (200) {id} product.id Product Id
-        @apiSuccess (200) {String} product.name Short form name of product
-        @apiSuccess (200) {String} product.description Long form description of product
-        @apiSuccess (200) {Number} product.price Cost of product
-        @apiSuccess (200) {Number} product.quantity Number of items to sell
-        @apiSuccess (200) {Date} product.created_date City where product is located
-        @apiSuccess (200) {String} product.location City where product is located
-        @apiSuccess (200) {String} product.image_path Path to product image
-        @apiSuccess (200) {Number} product.average_rating Average customer rating of product
-        @apiSuccess (200) {Number} product.number_sold How many items have been purchased
-        @apiSuccess (200) {Object} product.category Category of product
-        @apiSuccessExample {json} Success
-            {
-                "id": 101,
-                "url": "http://localhost:8000/products/101",
-                "name": "Kite",
-                "price": 14.99,
-                "number_sold": 0,
-                "description": "It flies high",
-                "quantity": 60,
-                "created_date": "2019-10-23",
-                "location": "Pittsburgh",
-                "image_path": null,
-                "average_rating": 0,
-                "category": {
-                    "url": "http://localhost:8000/productcategories/6",
-                    "name": "Games/Toys"
-                }
-            }
-        """
         try:
             product = Product.objects.get(pk=pk)
-            serializer = ProductSerializer(product, context={'request': request})
+            serializer = ProductSerializer(product, context={"request": request})
             return Response(serializer.data)
         except Exception as ex:
             return HttpResponseServerError(ex)
 
     def update(self, request, pk=None):
-        """
-        @api {PUT} /products/:id PUT changes to product
-        @apiName UpdateProduct
-        @apiGroup Product
-
-        @apiHeader {String} Authorization Auth token
-        @apiHeaderExample {String} Authorization
-            Token 9ba45f09651c5b0c404f37a2d2572c026c146611
-
-        @apiParam {id} id Product Id to update
-        @apiSuccessExample {json} Success
-            HTTP/1.1 204 No Content
-        """
         product = Product.objects.get(pk=pk)
         product.name = request.data["name"]
         product.price = request.data["price"]
@@ -189,107 +96,68 @@ class Products(ViewSet):
         return Response({}, status=status.HTTP_204_NO_CONTENT)
 
     def destroy(self, request, pk=None):
-        """
-        @api {DELETE} /products/:id DELETE product
-        @apiName DeleteProduct
-        @apiGroup Product
-
-        @apiHeader {String} Authorization Auth token
-        @apiHeaderExample {String} Authorization
-            Token 9ba45f09651c5b0c404f37a2d2572c026c146611
-
-        @apiParam {id} id Product Id to delete
-        @apiSuccessExample {json} Success
-            HTTP/1.1 204 No Content
-        """
         try:
             product = Product.objects.get(pk=pk)
             product.delete()
-
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 
         except Product.DoesNotExist as ex:
-            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 
         except Exception as ex:
-            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"message": ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
     def list(self, request):
-        """
-        @api {GET} /products GET all products
-        @apiName ListProducts
-        @apiGroup Product
-
-        @apiSuccess (200) {Object[]} products Array of products
-        @apiSuccessExample {json} Success
-            [
-                {
-                    "id": 101,
-                    "url": "http://localhost:8000/products/101",
-                    "name": "Kite",
-                    "price": 14.99,
-                    "number_sold": 0,
-                    "description": "It flies high",
-                    "quantity": 60,
-                    "created_date": "2019-10-23",
-                    "location": "Pittsburgh",
-                    "image_path": null,
-                    "average_rating": 0,
-                    "category": {
-                        "url": "http://localhost:8000/productcategories/6",
-                        "name": "Games/Toys"
-                    }
-                }
-            ]
-        """
         products = Product.objects.all()
 
-        # Support filtering by category and/or quantity
-        category = self.request.query_params.get('category', None)
-        quantity = self.request.query_params.get('quantity', None)
-        order = self.request.query_params.get('order_by', None)
-        direction = self.request.query_params.get('direction', None)
-        number_sold = self.request.query_params.get('number_sold', None)
+        category = self.request.query_params.get("category", None)
+        quantity = self.request.query_params.get("quantity", None)
+        order = self.request.query_params.get("order_by", None)
+        direction = self.request.query_params.get("direction", None)
+        number_sold = self.request.query_params.get("number_sold", None)
 
         if order is not None:
             order_filter = order
-
-            if direction is not None:
-                if direction == "desc":
-                    order_filter = f'-{order}'
-
+            if direction is not None and direction == "desc":
+                order_filter = f"-{order}"
             products = products.order_by(order_filter)
 
         if category is not None:
             products = products.filter(category__id=category)
 
         if quantity is not None:
-            products = products.order_by("-created_date")[:int(quantity)]
+            products = products.order_by("-created_date")[: int(quantity)]
 
         if number_sold is not None:
+
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                # OLD BUGGY CODE:
+                # if product.number_sold <= int(number_sold):
+                #     return True
+
+                # NEW FIXED CODE:
+                if product.number_sold >= int(number_sold):
                     return True
+
                 return False
 
             products = filter(sold_filter, products)
 
         serializer = ProductSerializer(
-            products, many=True, context={'request': request})
+            products, many=True, context={"request": request}
+        )
         return Response(serializer.data)
 
-    @action(methods=['post'], detail=True)
+    @action(methods=["post"], detail=True)
     def recommend(self, request, pk=None):
-        """Recommend products to other users"""
-
         if request.method == "POST":
             rec = Recommendation()
             rec.recommender = Customer.objects.get(user=request.auth.user)
             rec.customer = Customer.objects.get(user__id=request.data["recipient"])
             rec.product = Product.objects.get(pk=pk)
-
             rec.save()
-
             return Response(None, status=status.HTTP_204_NO_CONTENT)
 
         return Response(None, status=status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -72,12 +72,30 @@ class Products(ViewSet):
         @apiSuccess (200) {String} product.description Long form description of product
         @apiSuccess (200) {Number} product.price Cost of product
         @apiSuccess (200) {Number} product.quantity Number of items to sell
-        @apiSuccess (200) {Date} product.created_date Date created
+        @apiSuccess (200) {Date} product.created_date City where product is located
         @apiSuccess (200) {String} product.location City where product is located
         @apiSuccess (200) {String} product.image_path Path to product image
         @apiSuccess (200) {Number} product.average_rating Average customer rating of product
         @apiSuccess (200) {Number} product.number_sold How many items have been purchased
         @apiSuccess (200) {Object} product.category Category of product
+        @apiSuccessExample {json} Success
+            {
+                "id": 101,
+                "url": "http://localhost:8000/products/101",
+                "name": "Kite",
+                "price": 14.99,
+                "number_sold": 0,
+                "description": "It flies high",
+                "quantity": 60,
+                "created_date": "2019-10-23",
+                "location": "Pittsburgh",
+                "image_path": null,
+                "average_rating": 0,
+                "category": {
+                    "url": "http://localhost:8000/productcategories/6",
+                    "name": "Games/Toys"
+                }
+            }
         """
         new_product = Product()
         new_product.name = request.data["name"]
@@ -99,6 +117,7 @@ class Products(ViewSet):
                 base64.b64decode(imgstr),
                 name=f'{new_product.id}-{request.data["name"]}.{ext}',
             )
+
             new_product.image_path = data
 
         new_product.save()
@@ -115,7 +134,36 @@ class Products(ViewSet):
 
         @apiParam {id} id Product Id
 
-        @apiSuccess (200) {Object} product Product details
+        @apiSuccess (200) {Object} product Created product
+        @apiSuccess (200) {id} product.id Product Id
+        @apiSuccess (200) {String} product.name Short form name of product
+        @apiSuccess (200) {String} product.description Long form description of product
+        @apiSuccess (200) {Number} product.price Cost of product
+        @apiSuccess (200) {Number} product.quantity Number of items to sell
+        @apiSuccess (200) {Date} product.created_date City where product is located
+        @apiSuccess (200) {String} product.location City where product is located
+        @apiSuccess (200) {String} product.image_path Path to product image
+        @apiSuccess (200) {Number} product.average_rating Average customer rating of product
+        @apiSuccess (200) {Number} product.number_sold How many items have been purchased
+        @apiSuccess (200) {Object} product.category Category of product
+        @apiSuccessExample {json} Success
+            {
+                "id": 101,
+                "url": "http://localhost:8000/products/101",
+                "name": "Kite",
+                "price": 14.99,
+                "number_sold": 0,
+                "description": "It flies high",
+                "quantity": 60,
+                "created_date": "2019-10-23",
+                "location": "Pittsburgh",
+                "image_path": null,
+                "average_rating": 0,
+                "category": {
+                    "url": "http://localhost:8000/productcategories/6",
+                    "name": "Games/Toys"
+                }
+            }
         """
         try:
             product = Product.objects.get(pk=pk)
@@ -131,6 +179,9 @@ class Products(ViewSet):
         @apiGroup Product
 
         @apiHeader {String} Authorization Auth token
+        @apiHeaderExample {String} Authorization
+            Token 9ba45f09651c5b0c404f37a2d2572c026c146611
+
         @apiParam {id} id Product Id to update
         @apiSuccessExample {json} Success
             HTTP/1.1 204 No Content
@@ -158,11 +209,18 @@ class Products(ViewSet):
         @apiName DeleteProduct
         @apiGroup Product
 
+        @apiHeader {String} Authorization Auth token
+        @apiHeaderExample {String} Authorization
+            Token 9ba45f09651c5b0c404f37a2d2572c026c146611
+
         @apiParam {id} id Product Id to delete
+        @apiSuccessExample {json} Success
+            HTTP/1.1 204 No Content
         """
         try:
             product = Product.objects.get(pk=pk)
             product.delete()
+
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 
         except Product.DoesNotExist as ex:
@@ -180,9 +238,30 @@ class Products(ViewSet):
         @apiGroup Product
 
         @apiSuccess (200) {Object[]} products Array of products
+        @apiSuccessExample {json} Success
+            [
+                {
+                    "id": 101,
+                    "url": "http://localhost:8000/products/101",
+                    "name": "Kite",
+                    "price": 14.99,
+                    "number_sold": 0,
+                    "description": "It flies high",
+                    "quantity": 60,
+                    "created_date": "2019-10-23",
+                    "location": "Pittsburgh",
+                    "image_path": null,
+                    "average_rating": 0,
+                    "category": {
+                        "url": "http://localhost:8000/productcategories/6",
+                        "name": "Games/Toys"
+                    }
+                }
+            ]
         """
         products = Product.objects.all()
 
+        # Support filtering by category and/or quantity
         category = self.request.query_params.get("category", None)
         quantity = self.request.query_params.get("quantity", None)
         order = self.request.query_params.get("order_by", None)
@@ -191,8 +270,11 @@ class Products(ViewSet):
 
         if order is not None:
             order_filter = order
-            if direction is not None and direction == "desc":
-                order_filter = f"-{order}"
+
+            if direction is not None:
+                if direction == "desc":
+                    order_filter = f"-{order}"
+
             products = products.order_by(order_filter)
 
         if category is not None:
@@ -204,10 +286,6 @@ class Products(ViewSet):
         if number_sold is not None:
 
             def sold_filter(product):
-                """
-                Filter products by number sold
-                """
-                # FIXED FOR TICKET 7:
                 if product.number_sold >= int(number_sold):
                     return True
                 return False
@@ -221,17 +299,16 @@ class Products(ViewSet):
 
     @action(methods=["post"], detail=True)
     def recommend(self, request, pk=None):
-        """
-        @api {POST} /products/:id/recommend Recommend product to another user
-        @apiName RecommendProduct
-        @apiGroup Product
-        """
+        """Recommend products to other users"""
+
         if request.method == "POST":
             rec = Recommendation()
             rec.recommender = Customer.objects.get(user=request.auth.user)
             rec.customer = Customer.objects.get(user__id=request.data["recipient"])
             rec.product = Product.objects.get(pk=pk)
+
             rec.save()
+
             return Response(None, status=status.HTTP_204_NO_CONTENT)
 
         return Response(None, status=status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -41,7 +41,44 @@ class Products(ViewSet):
     permission_classes = (IsAuthenticatedOrReadOnly,)
 
     def create(self, request):
-        """Handle POST operations for creating a new product"""
+        """
+        @api {POST} /products POST new product
+        @apiName CreateProduct
+        @apiGroup Product
+
+        @apiHeader {String} Authorization Auth token
+        @apiHeaderExample {String} Authorization
+            Token 9ba45f09651c5b0c404f37a2d2572c026c146611
+
+        @apiParam {String} name Short form name of product
+        @apiParam {Number} price Cost of product
+        @apiParam {String} description Long form description of product
+        @apiParam {Number} quantity Number of items to sell
+        @apiParam {String} location City where product is located
+        @apiParam {Number} category_id Category of product
+        @apiParamExample {json} Input
+            {
+                "name": "Kite",
+                "price": 14.99,
+                "description": "It flies high",
+                "quantity": 60,
+                "location": "Pittsburgh",
+                "category_id": 4
+            }
+
+        @apiSuccess (200) {Object} product Created product
+        @apiSuccess (200) {id} product.id Product Id
+        @apiSuccess (200) {String} product.name Short form name of product
+        @apiSuccess (200) {String} product.description Long form description of product
+        @apiSuccess (200) {Number} product.price Cost of product
+        @apiSuccess (200) {Number} product.quantity Number of items to sell
+        @apiSuccess (200) {Date} product.created_date Date created
+        @apiSuccess (200) {String} product.location City where product is located
+        @apiSuccess (200) {String} product.image_path Path to product image
+        @apiSuccess (200) {Number} product.average_rating Average customer rating of product
+        @apiSuccess (200) {Number} product.number_sold How many items have been purchased
+        @apiSuccess (200) {Object} product.category Category of product
+        """
         new_product = Product()
         new_product.name = request.data["name"]
         new_product.price = request.data["price"]
@@ -71,7 +108,15 @@ class Products(ViewSet):
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def retrieve(self, request, pk=None):
-        """Handle GET requests for a single product"""
+        """
+        @api {GET} /products/:id GET product
+        @apiName GetProduct
+        @apiGroup Product
+
+        @apiParam {id} id Product Id
+
+        @apiSuccess (200) {Object} product Product details
+        """
         try:
             product = Product.objects.get(pk=pk)
             serializer = ProductSerializer(product, context={"request": request})
@@ -80,7 +125,16 @@ class Products(ViewSet):
             return HttpResponseServerError(ex)
 
     def update(self, request, pk=None):
-        """Handle PUT requests for updating a product"""
+        """
+        @api {PUT} /products/:id PUT changes to product
+        @apiName UpdateProduct
+        @apiGroup Product
+
+        @apiHeader {String} Authorization Auth token
+        @apiParam {id} id Product Id to update
+        @apiSuccessExample {json} Success
+            HTTP/1.1 204 No Content
+        """
         product = Product.objects.get(pk=pk)
         product.name = request.data["name"]
         product.price = request.data["price"]
@@ -99,7 +153,13 @@ class Products(ViewSet):
         return Response({}, status=status.HTTP_204_NO_CONTENT)
 
     def destroy(self, request, pk=None):
-        """Handle DELETE requests for a product"""
+        """
+        @api {DELETE} /products/:id DELETE product
+        @apiName DeleteProduct
+        @apiGroup Product
+
+        @apiParam {id} id Product Id to delete
+        """
         try:
             product = Product.objects.get(pk=pk)
             product.delete()
@@ -114,7 +174,13 @@ class Products(ViewSet):
             )
 
     def list(self, request):
-        """Handle GET requests for all products, including filtering and ordering"""
+        """
+        @api {GET} /products GET all products
+        @apiName ListProducts
+        @apiGroup Product
+
+        @apiSuccess (200) {Object[]} products Array of products
+        """
         products = Product.objects.all()
 
         category = self.request.query_params.get("category", None)
@@ -138,15 +204,12 @@ class Products(ViewSet):
         if number_sold is not None:
 
             def sold_filter(product):
-                """Filter helper to return products sold >= requested amount"""
-                # OLD BUGGY CODE:
-                # if product.number_sold <= int(number_sold):
-                #     return True
-
-                # NEW FIXED CODE:
+                """
+                Filter products by number sold
+                """
+                # FIXED FOR TICKET 7:
                 if product.number_sold >= int(number_sold):
                     return True
-
                 return False
 
             products = filter(sold_filter, products)
@@ -158,7 +221,11 @@ class Products(ViewSet):
 
     @action(methods=["post"], detail=True)
     def recommend(self, request, pk=None):
-        """Custom action to recommend a product to another user"""
+        """
+        @api {POST} /products/:id/recommend Recommend product to another user
+        @apiName RecommendProduct
+        @apiGroup Product
+        """
         if request.method == "POST":
             rec = Recommendation()
             rec.recommender = Customer.objects.get(user=request.auth.user)


### PR DESCRIPTION
Description of PR that completes issue here...

This PR resolves Ticket #7, which reported incorrect behavior in the /products endpoint when filtering by number_sold. The previous implementation returned products sold less than or equal to the requested value. The correct behavior is to return products sold greater than or equal to the requested value. This PR updates the filter logic accordingly and includes a safeguard to prevent ZeroDivisionError when serializing unrated products.

## Changes

- Updated sold_filter in views/product.py to return products with number_sold >= X
- Added defensive check in average_rating to prevent division by zero when a product has no ratings (This occurred in bangazonapi/models/product.py, all other changes were in views/product.py)
- Verified endpoint behavior and ensured compatibility with existing filters (category, ordering, quantity)

## Requests / Responses

This PR does not introduce new endpoints or modify request/response schemas.
It only corrects backend filtering logic.

**Request**

GET /products?number_sold=2

**Response**
```
[
  {
    "id": 50,
    "name": "Golf",
    "price": 653.59,
    "number_sold": 2,
    "description": "1994 Volkswagen",
    "quantity": 4,
    "created_date": "2019-07-10",
    "location": "Berlin",
    "image_path": "http://localhost:8000/media/products/golf.png",
    "average_rating": 3.25
  }
]
```
## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Hit GET /products?number_sold=2 in Yaak (make sure under the params tab it says "number_sold" in the param_name field and "2" in the value field)
- [ ] Confirm only products with number_sold >= 2 are returned
- [ ] Confirm no ZeroDivisionError occurs when products have no ratings
- [ ] Confirm combined filters still work (category, ordering, quantity)

## Related Issues

- Fixes #7